### PR TITLE
Join leave events

### DIFF
--- a/controllers/controllerhelpers/playerHelpers.go
+++ b/controllers/controllerhelpers/playerHelpers.go
@@ -30,7 +30,7 @@ func AfterLobbyJoin(server *wsevent.Server, so *wsevent.Client, lobby *models.Lo
 	room := fmt.Sprintf("%s_private", GetLobbyRoom(lobby.ID))
 	server.AddClient(so, room)
 
-	bytes, _ := models.DecorateLobbyJoinJSON(lobby, player).Encode()
+	bytes, _ := models.DecorateLobbyJoinJSON(lobby).Encode()
 	broadcaster.SendMessage(player.SteamId, "lobbyJoin", string(bytes))
 }
 
@@ -38,7 +38,7 @@ func AfterLobbyLeave(server *wsevent.Server, so *wsevent.Client, lobby *models.L
 	server.RemoveClient(so.Id(), fmt.Sprintf("%s_private", GetLobbyRoom(lobby.ID)))
 	server.RemoveClient(so.Id(), fmt.Sprintf("%s_public", GetLobbyRoom(lobby.ID)))
 
-	bytes, _ := models.DecorateLobbyLeaveJSON(lobby, player).Encode()
+	bytes, _ := models.DecorateLobbyLeaveJSON(lobby).Encode()
 	broadcaster.SendMessage(player.SteamId, "lobbyLeave", string(bytes))
 }
 

--- a/controllers/controllerhelpers/playerHelpers.go
+++ b/controllers/controllerhelpers/playerHelpers.go
@@ -26,15 +26,20 @@ var BanTypeMap = map[string]models.PlayerBanType{
 	"full":   models.PlayerBanFull,
 }
 
-func AfterLobbyJoin(server *wsevent.Server, so *wsevent.Client, lobby *models.Lobby,
-	player *models.Player) {
-	server.AddClient(so, fmt.Sprintf("%s_private", GetLobbyRoom(lobby.ID)))
+func AfterLobbyJoin(server *wsevent.Server, so *wsevent.Client, lobby *models.Lobby, player *models.Player) {
+	room := fmt.Sprintf("%s_private", GetLobbyRoom(lobby.ID))
+	server.AddClient(so, room)
+
+	bytes, _ := models.DecorateLobbyJoinJSON(lobby, player).Encode()
+	broadcaster.SendMessage(player.SteamId, "lobbyJoin", string(bytes))
 }
 
-func AfterLobbyLeave(server *wsevent.Server, so *wsevent.Client, lobby *models.Lobby,
-	player *models.Player) {
+func AfterLobbyLeave(server *wsevent.Server, so *wsevent.Client, lobby *models.Lobby, player *models.Player) {
 	server.RemoveClient(so.Id(), fmt.Sprintf("%s_private", GetLobbyRoom(lobby.ID)))
 	server.RemoveClient(so.Id(), fmt.Sprintf("%s_public", GetLobbyRoom(lobby.ID)))
+
+	bytes, _ := models.DecorateLobbyLeaveJSON(lobby, player).Encode()
+	broadcaster.SendMessage(player.SteamId, "lobbyLeave", string(bytes))
 }
 
 func AfterLobbySpec(server *wsevent.Server, so *wsevent.Client, lobby *models.Lobby) {

--- a/models/lobby_decorators.go
+++ b/models/lobby_decorators.go
@@ -117,3 +117,21 @@ func DecorateLobbyConnectJSON(lobby *Lobby) *simplejson.Json {
 
 	return json
 }
+
+func DecorateLobbyJoinJSON(lobby *Lobby, player *Player) *simplejson.Json {
+	json := simplejson.New()
+
+	json.Set("lobbyId", lobby.ID)
+	json.Set("playerId", player.SteamId)
+
+	return json
+}
+
+func DecorateLobbyLeaveJSON(lobby *Lobby, player *Player) *simplejson.Json {
+	json := simplejson.New()
+
+	json.Set("lobbyId", lobby.ID)
+	json.Set("playerId", player.SteamId)
+
+	return json
+}

--- a/models/lobby_decorators.go
+++ b/models/lobby_decorators.go
@@ -118,20 +118,18 @@ func DecorateLobbyConnectJSON(lobby *Lobby) *simplejson.Json {
 	return json
 }
 
-func DecorateLobbyJoinJSON(lobby *Lobby, player *Player) *simplejson.Json {
+func DecorateLobbyJoinJSON(lobby *Lobby) *simplejson.Json {
 	json := simplejson.New()
 
 	json.Set("lobbyId", lobby.ID)
-	json.Set("playerId", player.SteamId)
 
 	return json
 }
 
-func DecorateLobbyLeaveJSON(lobby *Lobby, player *Player) *simplejson.Json {
+func DecorateLobbyLeaveJSON(lobby *Lobby) *simplejson.Json {
 	json := simplejson.New()
 
 	json.Set("lobbyId", lobby.ID)
-	json.Set("playerId", player.SteamId)
 
 	return json
 }


### PR DESCRIPTION
Sort of fixes #86 . The lobbyJoin/Leave events aren't broadcast to everyone as I described in #86, instead they are only broadcast to the user that left/joined a lobby. This is actually helpful because if the events were sent to everyone, then (aside from the flood of messages most clients would ignore), the clients would have to know their steamid to look for. However, the first lobbyJoin message sent to a newly connected client can arrive before that client's player data, so they would end up ignoring it and thus not know they're in a lobby.