### PR TITLE
Localizations

### DIFF
--- a/config/localizations.go
+++ b/config/localizations.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"path/filepath"
+
+	"github.com/N1xx1/golang-i18n"
+	"github.com/TF2Stadium/Helen/helpers"
+)
+
+func InitializeLocalizations(fileName string) {
+	realPath, err := filepath.Abs(fileName)
+	if err != nil {
+		helpers.Logger.Fatal(err.Error())
+	}
+	err = i18n.GlobalTfunc(realPath)
+	if err != nil {
+		helpers.Logger.Fatal(err.Error())
+	}
+}

--- a/en-US.i18n
+++ b/en-US.i18n
@@ -1,0 +1,15 @@
+# LOBBY SETTINGS STRINGS
+
+lobby-settings-format = "Format"
+
+lobby-settings-map = "Map"
+
+lobby-settings-league = "League"
+
+lobby-settings-whitelist = "Whitelist"
+
+lobby-settings-mumble = "Mumble required"
+lobby-settings-mumble-required = "Mumble required"
+lobby-settings-mumble-required-desc = "All participants will need to join the mumble channel."
+lobby-settings-mumble-not-required = "Mumble not required"
+lobby-settings-mumble-not-required-desc = "Participants will join the mumble only if they want to do so."

--- a/main.go
+++ b/main.go
@@ -27,15 +27,17 @@ import (
 
 func main() {
 	authority.RegisterTypes()
+
 	helpers.InitLogger()
 	helpers.InitAuthorization()
 	config.SetupConstants()
+	config.InitializeLocalizations("./en-US.i18n")
 	database.Init()
 	migrations.Do()
 	stores.SetupStores()
 	models.PaulingConnect()
 	models.InitializeLobbySettings("./lobbySettingsData.json")
-	
+
 	go models.ReadyTimeoutListener()
 	StartListener()
 	chelpers.CheckLogger()

--- a/models/lobbySettings.go
+++ b/models/lobbySettings.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/N1xx1/golang-i18n"
 	"github.com/TF2Stadium/Helen/helpers"
 	"github.com/bitly/go-simplejson"
 )
@@ -109,9 +110,8 @@ func InitializeLobbySettings(fileName string) {
 	realPath, err := filepath.Abs(fileName)
 	if err != nil {
 		helpers.Logger.Fatal(err.Error())
-		return
 	}
-	
+
 	err = LoadLobbySettingsFromFile(realPath)
 	if err != nil {
 		helpers.Logger.Fatal(err.Error())
@@ -269,7 +269,7 @@ func LobbySettingsToJson() *simplejson.Json {
 			formatList[i] = f
 		}
 		formats.Set("key", "type")
-		formats.Set("title", "Format")
+		formats.Set("title", i18n.T("lobby-settings-format"))
 		formats.Set("options", formatList)
 
 		j.Set("formats", formats)
@@ -290,7 +290,7 @@ func LobbySettingsToJson() *simplejson.Json {
 			mapList[i] = f
 		}
 		maps.Set("key", "mapName")
-		maps.Set("title", "Map")
+		maps.Set("title", i18n.T("lobby-settings-map"))
 		maps.Set("options", mapList)
 
 		j.Set("maps", maps)
@@ -318,7 +318,7 @@ func LobbySettingsToJson() *simplejson.Json {
 			leagueList[i] = f
 		}
 		leagues.Set("key", "league")
-		leagues.Set("title", "League")
+		leagues.Set("title", i18n.T("lobby-settings-league"))
 		leagues.Set("options", leagueList)
 
 		j.Set("leagues", leagues)
@@ -339,10 +339,32 @@ func LobbySettingsToJson() *simplejson.Json {
 			whitelistList[i] = f
 		}
 		whitelists.Set("key", "whitelist")
-		whitelists.Set("title", "Whitelist")
+		whitelists.Set("title", i18n.T("lobby-settings-whitelist"))
 		whitelists.Set("options", whitelistList)
 
 		j.Set("whitelists", whitelists)
+	}
+
+	// mumble
+	{
+		mumble := simplejson.New()
+
+		mumbleList := make([]*simplejson.Json, 2)
+		mumbleList[0] = simplejson.New()
+		mumbleList[0].Set("value", true)
+		mumbleList[0].Set("title", i18n.T("lobby-settings-mumble-required"))
+		mumbleList[0].Set("description", i18n.T("lobby-settings-mumble-required-desc"))
+
+		mumbleList[1] = simplejson.New()
+		mumbleList[1].Set("value", false)
+		mumbleList[1].Set("title", i18n.T("lobby-settings-mumble-not-required"))
+		mumbleList[1].Set("description", i18n.T("lobby-settings-mumble-not-required-desc"))
+
+		mumble.Set("key", "mumbleRequired")
+		mumble.Set("title", i18n.T("lobby-settings-mumble"))
+		mumble.Set("options", mumbleList)
+
+		j.Set("mumble", mumble)
 	}
 
 	return j

--- a/models/lobbySettings.go
+++ b/models/lobbySettings.go
@@ -35,6 +35,21 @@ type LobbyMap struct {
 	Formats []*LobbyMapFormat `gorm:"many2many:lobby_map_formats"`
 }
 
+func (m *LobbyMap) GetFormat(formatName string) (*LobbyMapFormat, bool) {
+	for _, mapFormat := range m.Formats {
+		if mapFormat.Format.Name == formatName {
+			return mapFormat, true
+		}
+	}
+	if format, ok := GetLobbyFormat(formatName); ok {
+		return &LobbyMapFormat{
+			Format:     format,
+			Importance: 0,
+		}, true
+	}
+	return nil, false
+}
+
 // TODO make int?
 type MapType string
 

--- a/models/lobbySettings_test.go
+++ b/models/lobbySettings_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/TF2Stadium/Helen/config"
 	"github.com/TF2Stadium/Helen/models"
 	"github.com/stretchr/testify/assert"
 )
@@ -65,6 +66,7 @@ var testSettingsData = []byte(`
 func TestSettingsLoad(t *testing.T) {
 	assert := assert.New(t)
 
+	config.InitializeLocalizations("../en-US.i18n")
 	err := models.LoadLobbySettings(testSettingsData)
 
 	if assert.Nil(err) {

--- a/models/lobbySettings_test.go
+++ b/models/lobbySettings_test.go
@@ -70,34 +70,46 @@ func TestSettingsLoad(t *testing.T) {
 	err := models.LoadLobbySettings(testSettingsData)
 
 	if assert.Nil(err) {
-		if assert.Equal(len(models.LobbyFormats), 3) {
-			assert.Equal(models.LobbyFormats[0].Name, "sixes")
-			assert.Equal(models.LobbyFormats[0].PrettyName, "6v6")
-			assert.Equal(models.LobbyFormats[0].Important, true)
-
-			assert.Equal(models.LobbyFormats[1].Name, "highlander")
-			assert.Equal(models.LobbyFormats[1].PrettyName, "Highlander")
-			assert.Equal(models.LobbyFormats[1].Important, true)
-
-			assert.Equal(models.LobbyFormats[2].Name, "fours")
-			assert.Equal(models.LobbyFormats[2].PrettyName, "4v4")
-			assert.Equal(models.LobbyFormats[2].Important, false)
-		}
-
-		if assert.Equal(len(models.LobbyMaps), 2) {
-			assert.Equal(models.LobbyMaps[0].Name, "cp_process_final")
-			if assert.Equal(len(models.LobbyMaps[0].Formats), 2) {
-				assert.Equal(models.LobbyMaps[0].Formats[0].Format.Name, "highlander")
-				assert.Equal(models.LobbyMaps[0].Formats[0].Importance, 1)
-
-				assert.Equal(models.LobbyMaps[0].Formats[1].Format.Name, "sixes")
-				assert.Equal(models.LobbyMaps[0].Formats[1].Importance, 2)
+		// test formats
+		if assert.Equal(3, len(models.LobbyFormats)) {
+			if format, ok := models.GetLobbyFormat("sixes"); assert.True(ok) {
+				assert.Equal("6v6", format.PrettyName)
+				assert.Equal(true, format.Important)
 			}
 
-			assert.Equal(models.LobbyMaps[1].Name, "pl_upward")
-			if assert.Equal(len(models.LobbyMaps[1].Formats), 1) {
-				assert.Equal(models.LobbyMaps[1].Formats[0].Format.Name, "highlander")
-				assert.Equal(models.LobbyMaps[1].Formats[0].Importance, 2)
+			if format, ok := models.GetLobbyFormat("highlander"); assert.True(ok) {
+				assert.Equal("Highlander", format.PrettyName)
+				assert.Equal(true, format.Important)
+			}
+
+			if format, ok := models.GetLobbyFormat("fours"); assert.True(ok) {
+				assert.Equal("4v4", format.PrettyName)
+				assert.Equal(false, format.Important)
+			}
+		}
+
+		// test maps
+		if assert.Equal(2, len(models.LobbyMaps)) {
+			if amap, ok := models.GetLobbyMap("cp_process_final"); assert.True(ok) {
+				assert.Equal(2, len(amap.Formats))
+
+				if mapFormat, ok := amap.GetFormat("highlander"); assert.True(ok) {
+					assert.Equal(1, mapFormat.Importance)
+				}
+				if mapFormat, ok := amap.GetFormat("sixes"); assert.True(ok) {
+					assert.Equal(2, mapFormat.Importance)
+				}
+				if mapFormat, ok := amap.GetFormat("fours"); assert.True(ok) {
+					assert.Equal(0, mapFormat.Importance)
+				}
+			}
+
+			if amap, ok := models.GetLobbyMap("pl_upward"); assert.True(ok) {
+				assert.Equal(1, len(amap.Formats))
+
+				if mapFormat, ok := amap.GetFormat("highlander"); assert.True(ok) {
+					assert.Equal(2, mapFormat.Importance)
+				}
 			}
 		}
 


### PR DESCRIPTION
I implemented a basic [localization library](https://github.com/N1xx1/golang-i18n/) into Helen. It loads a config file that has this structure:

    # comment
    key-name-1 = "Value String 1"
    key-name-2 = "Value String 2"

And enables you to use a convienent `i18n.T(key, args...)` function that does a Sprintf on the value if it's found, or returns the key if it isn't.

I use it to translate some stuff for the frontend, i.e. the lobby settings section's title. 
I've also added the mumble required information to the setting list and made some tweaks to it.