### PR TITLE
lobbyListData: output is an array of lobbies

### DIFF
--- a/controllers/controllerhelpers/hooks/player.go
+++ b/controllers/controllerhelpers/hooks/player.go
@@ -27,7 +27,7 @@ func AfterConnect(server *wsevent.Server, so *wsevent.Client) {
 		return
 	}
 
-	so.EmitJSON(helpers.NewRequest("lobbyListData", lobbies))
+	so.EmitJSON(helpers.NewRequest("lobbyListData", models.DecorateLobbyListData(lobbies)))
 	chelpers.BroadcastScrollback(so, 0)
 	so.EmitJSON(helpers.NewRequest("subListData", models.GetAllSubs()))
 }

--- a/controllers/socket/internal/handler/lobby.go
+++ b/controllers/socket/internal/handler/lobby.go
@@ -616,7 +616,7 @@ func (Lobby) LobbySpectatorLeave(server *wsevent.Server, so *wsevent.Client, dat
 func (Lobby) RequestLobbyListData(_ *wsevent.Server, so *wsevent.Client, data []byte) interface{} {
 	var lobbies []models.Lobby
 	db.DB.Where("state = ?", models.LobbyStateWaiting).Order("id desc").Find(&lobbies)
-	so.EmitJSON(helpers.NewRequest("lobbyListData", lobbies))
+	so.EmitJSON(helpers.NewRequest("lobbyListData", models.DecorateLobbyListData(lobbies)))
 
 	return chelpers.EmptySuccessJS
 }

--- a/models/lobby.go
+++ b/models/lobby.go
@@ -749,7 +749,8 @@ func BroadcastLobbyList() {
 	lobbies := []Lobby{}
 	db.DB.Where("state = ?", LobbyStateWaiting).Order("id desc").Find(&lobbies)
 	broadcaster.SendMessageToRoom(
-		fmt.Sprintf("%s_public", config.Constants.GlobalChatRoom), "lobbyListData", lobbies)
+		fmt.Sprintf("%s_public", config.Constants.GlobalChatRoom),
+		"lobbyListData", DecorateLobbyListData(lobbies))
 }
 
 func (l *Lobby) LobbyData(include bool) LobbyData {

--- a/models/lobby_decorators.go
+++ b/models/lobby_decorators.go
@@ -191,6 +191,23 @@ func (l LobbyData) SendToPlayer(steamid string) {
 	broadcaster.SendMessage(steamid, "lobbyData", l)
 }
 
+func DecorateLobbyListData(lobbies []Lobby) LobbyListData {
+	if len(lobbies) == 0 {
+		return LobbyListData{}
+	}
+
+	var lobbyList = make([]LobbyData, len(lobbies))
+
+	for i, lobby := range lobbies {
+		lobbyData := DecorateLobbyData(&lobby, false)
+		lobbyList[i] = lobbyData
+	}
+
+	listObj := LobbyListData{lobbyList}
+
+	return listObj
+}
+
 func sanitize(name string) string {
 	var final string
 	for _, c := range name {

--- a/models/lobby_decorators.go
+++ b/models/lobby_decorators.go
@@ -191,11 +191,7 @@ func (l LobbyData) SendToPlayer(steamid string) {
 	broadcaster.SendMessage(steamid, "lobbyData", l)
 }
 
-func DecorateLobbyListData(lobbies []Lobby) LobbyListData {
-	if len(lobbies) == 0 {
-		return LobbyListData{}
-	}
-
+func DecorateLobbyListData(lobbies []Lobby) []LobbyData {
 	var lobbyList = make([]LobbyData, len(lobbies))
 
 	for i, lobby := range lobbies {
@@ -203,9 +199,7 @@ func DecorateLobbyListData(lobbies []Lobby) LobbyListData {
 		lobbyList[i] = lobbyData
 	}
 
-	listObj := LobbyListData{lobbyList}
-
-	return listObj
+	return lobbyList
 }
 
 func sanitize(name string) string {


### PR DESCRIPTION
Reverts https://github.com/TF2Stadium/Helen/pull/124
and does it correctly this time

lobbyListData's data used to be in this format {lobbies: [...]} (except the lobbies key wasn't there if the list was empty)

sending just an array back matches subListData's behavior

requires TF2Stadium/Frontend#143 to be merged for the frontend to work with this change.
