### PR TITLE
deleted chat messages include all the player's tags

### DIFF
--- a/controllers/socket/handler/chat.go
+++ b/controllers/socket/handler/chat.go
@@ -121,7 +121,7 @@ func (Chat) ChatDelete(so *wsevent.Client, data []byte) interface{} {
 	message.Save()
 	message.Message = "<deleted>"
 	message.Player = models.DecoratePlayerSummary(player)
-	message.Player.Tags = []string{"deleted"}
+	message.Player.Tags = append(message.Player.Tags, "deleted")
 	message.Send()
 
 	return chelpers.EmptySuccessJS


### PR DESCRIPTION
this way, if an admin or mod's message gets deleted, they won't also lose their chat badge for that message