### PR TITLE
Increase max chat length

### DIFF
--- a/controllers/socket/handler/chat.go
+++ b/controllers/socket/handler/chat.go
@@ -71,7 +71,7 @@ func (Chat) ChatSend(so *wsevent.Client, data []byte) interface{} {
 	case (*args.Message)[0] == '\n':
 		return helpers.NewTPError("Cannot send messages prefixed with newline", 4)
 
-	case len(*args.Message) > 120:
+	case len(*args.Message) > 150:
 		return helpers.NewTPError("Message too long", 4)
 	}
 

--- a/database/migrations/changes.go
+++ b/database/migrations/changes.go
@@ -12,7 +12,7 @@ import (
 
 //follows semantic versioning scheme
 var schemaVersion = semver.Version{
-	Major: 3,
+	Major: 4,
 	Minor: 0,
 	Patch: 0,
 }

--- a/database/migrations/routines.go
+++ b/database/migrations/routines.go
@@ -15,6 +15,7 @@ import (
 var migrationRoutines = map[uint64]func(){
 	2: lobbyTypeChange,
 	3: dropSubtituteTable,
+	4: increaseChatMessageLength,
 }
 
 func whitelist_id_string() {
@@ -66,4 +67,8 @@ func lobbyTypeChange() {
 
 func dropSubtituteTable() {
 	db.DB.Exec("DROP TABLE substitutes")
+}
+
+func increaseChatMessageLength() {
+	db.DB.Exec("ALTER TABLE chat_messages ALTER COLUMN message TYPE character varying(150)")
 }

--- a/models/chat.go
+++ b/models/chat.go
@@ -24,8 +24,8 @@ type ChatMessage struct {
 
 	// Room to which the message was sent
 	Room int `json:"room"`
-	// The actual Message, limited to 120 characters
-	Message string `json:"message" sql:"type:varchar(120)"`
+	// The actual Message, limited to 150 characters
+	Message string `json:"message" sql:"type:varchar(150)"`
 	// True if the message has been deleted by a moderator
 	Deleted bool `json:"deleted"`
 	// true if the message is sent by a bot


### PR DESCRIPTION
Allow chat messages to be 150 characters long, to match frontend release v0.7.0-alpha