### PR TITLE
deleted chat messages include all the player's tags

### DIFF
--- a/controllers/socket/handler/chat.go
+++ b/controllers/socket/handler/chat.go
@@ -121,7 +121,7 @@ func (Chat) ChatDelete(so *wsevent.Client, data []byte) interface{} {
 	message.Save()
 	message.Message = "<deleted>"
 	message.Player = models.DecoratePlayerSummary(player)
-	message.Player.Tags = []string{"deleted"}
+	message.Player.Tags = append(message.Player.Tags, "deleted")
 	message.Send()
 
 	return chelpers.EmptySuccessJS


### PR DESCRIPTION
This way, if an admin/mods message gets deleted, they don't randomly lose their chat badges for that message only.