### PR TITLE
Send chat scrollback as a single message

### DIFF
--- a/controllers/controllerhelpers/chatScrollback.go
+++ b/controllers/controllerhelpers/chatScrollback.go
@@ -15,7 +15,5 @@ func BroadcastScrollback(so *wsevent.Client, room uint) {
 		return
 	}
 
-	for i := len(messages) - 1; i != -1; i-- {
-		so.EmitJSON(helpers.NewRequest("chatReceive", messages[i]))
-	}
+	so.EmitJSON(helpers.NewRequest("chatScrollback", messages))
 }


### PR DESCRIPTION
the frontend supports this now, and this helps the (angular-constrained) frontend reduce layout-thrashing.