### PR TITLE
always send playerSettings

### DIFF
--- a/controllers/controllerhelpers/hooks/player.go
+++ b/controllers/controllerhelpers/hooks/player.go
@@ -58,6 +58,8 @@ func AfterConnectLoggedIn(so *wsevent.Client, player *models.Player) {
 	settings := player.Settings
 	if settings != nil {
 		broadcaster.SendMessage(player.SteamID, "playerSettings", settings)
+	} else {
+		broadcaster.SendMessage(player.SteamID, "playerSettings", map[string]string{})
 	}
 
 	player.SetPlayerProfile()


### PR DESCRIPTION
The frontend relies on this behaviour, otherwise it can't know if the use has no settings saved yet or if the playerSettings message just hasn't been received yet.

Signed-off-by: gpittarelli <tf2stadium@gjp.cc>