### PR TITLE
Send message when a lobby is created

### DIFF
--- a/controllers/socket/handler/lobby.go
+++ b/controllers/socket/handler/lobby.go
@@ -337,6 +337,8 @@ func (Lobby) LobbyCreate(so *wsevent.Client, args struct {
 		}
 	}
 
+	chat.NewBotMessage(fmt.Sprintf("Lobby created by %s", p.Alias()), int(lob.ID)).Send()
+
 	lobby.BroadcastLobbyList()
 	return newResponse(
 		struct {


### PR DESCRIPTION
This is nice because we never should have an empty chatroom (which looks lame). Also gives a full log of who made the lobby despite lobby-leader-changes.

Signed-off-by: gpittarelli <tf2stadium@gjp.cc>