### PR TITLE
Reword some error messages

### DIFF
--- a/models/lobby/lobby.go
+++ b/models/lobby/lobby.go
@@ -39,17 +39,17 @@ const (
 )
 
 var (
-	ErrLobbyNotFound   = errors.New("Couldn't find lobby with given ID")
+	ErrLobbyNotFound   = errors.New("Could not find lobby with given ID")
 	ErrLobbyBan        = errors.New("You have been banned from this lobby")
-	ErrBadSlot         = errors.New("This slot does not exist")
-	ErrFilled          = errors.New("This slot has been filled")
-	ErrNotWhitelisted  = errors.New("You aren't allowed in this lobby")
-	ErrInvalidPassword = errors.New("Invalid slot password")
+	ErrBadSlot         = errors.New("That slot does not exist")
+	ErrFilled          = errors.New("That slot has been filled")
+	ErrNotWhitelisted  = errors.New("You are not allowed in this lobby")
+	ErrInvalidPassword = errors.New("Incorrect slot password")
 	ErrNeedsSub        = errors.New("This slot needs a substitute")
 
-	ErrReqHours       = errors.New("You don't have sufficient hours to join this lobby")
-	ErrReqLobbies     = errors.New("You haven't played sufficient lobbies to join this lobby")
-	ErrReqReliability = errors.New("You have insufficient reliability to join this lobby")
+	ErrReqHours       = errors.New("You do not have sufficient hours to join that slot")
+	ErrReqLobbies     = errors.New("You have not played sufficient lobbies to join that slot")
+	ErrReqReliability = errors.New("You have insufficient reliability to join that slot")
 )
 
 // Represents an occupied player slot in a lobby


### PR DESCRIPTION
Most significant change is "lobby" -> "slot" in the requirement errors,
to reflect that those errors are per-slot now, not per-lobby

Also cleaned up the use of contractions (typically avoided in formal
writing) and changing "this"->"that"