### PR TITLE
Update koth_product to _rcx

### DIFF
--- a/assets/lobbySettingsData.json
+++ b/assets/lobbySettingsData.json
@@ -77,7 +77,7 @@
 			}
 		},
 		{
-			"name": "koth_product_rc8",
+			"name": "koth_product_rcx",
 			"formats": {
 				"sixes": 1,
 				"highlander": 1


### PR DESCRIPTION
User request

https://tf2maps.net/downloads/product.1063/updates confirms that _rcx is indeed a version of the map.